### PR TITLE
Update Installation_on_Unix.md

### DIFF
--- a/en/Installation_on_Unix.md
+++ b/en/Installation_on_Unix.md
@@ -22,3 +22,8 @@ sudo easy_install pip
 ```
 sudo pip install -U instabot
 ```
+
+* If you still have `permission denied` error after `sudo pip install -U instabot`, try:
+```
+sudo -H pip install -U instabot
+```


### PR DESCRIPTION
# Background
After trying `sudo pip` command permission errors are still happening

# Changes done
- Add `-H` to sudo command

> **-H, --set-home**
> _Request that the security policy set the HOME environment variable to the home directory specified by the target user's password database entry. Depending on the policy, this may be the default behavior._ 